### PR TITLE
Provide option to show solutions overview with the score

### DIFF
--- a/src/Default.html
+++ b/src/Default.html
@@ -80,6 +80,18 @@
                         <span data-bind="visible: !quizPassed()">FAIL</span>
                     </h1>
                 </div>
+                <div class="solutions">
+                    <div data-bind="foreach: { data: questions, as: 'question' }">
+                        <h3>
+                            Question <span data-bind="text: question.index"></span> (
+                            <span data-bind="css: {'text-success': question.correct }, visible: question.correct">Correct</span>
+                            <span data-bind="css: {'text-danger': !question.correct }, visible: !question.correct">Wrong</span>
+                            )
+                        </h3>
+                    <div data-bind="attr: {'id': 'solution-' + question.index}"></div>
+                </div>
+		</div>
+
             </section>
         </div>
     </section>

--- a/src/js/jsQuizEngine.js
+++ b/src/js/jsQuizEngine.js
@@ -35,6 +35,9 @@
             });
 
             self.questionCount(getAllQuestions(self.element).length);
+    	    for (var i = 1; i <=  self.questionCount(); i++) {
+	        	self.questions.push({ index: i, content: getQuestionByIndex(self.element, i), correct: false});
+	        }
             self.quizTitle(getCurrentQuiz(self.element).attr('data-title'));
             self.quizSubTitle(getCurrentQuiz(self.element).attr('data-subtitle'));
         });
@@ -45,6 +48,7 @@
         self.quizTitle = ko.observable('');
         self.quizSubTitle = ko.observable('');
         self.questionCount = ko.observable(0);
+        self.questions = ko.observableArray([]);
 
         self.currentQuestionIndex = ko.observable(0);
         self.currentQuestionIndex.subscribe(function (newValue) {
@@ -98,8 +102,6 @@
             q.find('.description').slideDown();
         };
 
-        
-
         self.calculateScore = function () {
             var correctQuestions = [];
             getAllQuestions(self.element).each(function (i, e) {
@@ -108,18 +110,30 @@
                     q.find('.answer[data-correct] > input[type=checkbox]:checked').length + q.find('.answer:not([data-correct]) > input[type=checkbox]:not(:checked)').length
                     )) {
                     correctQuestions.push(q);
+                    self.questions()[i] = { index: self.questions()[i].index, content: self.questions()[i].content, correct: true};
                 }
             });
-            self.totalQuestionsCorrect(correctQuestions.length);
+    	    self.questions.valueHasMutated(); // required for updating the view
 
+            self.totalQuestionsCorrect(correctQuestions.length);
             if (self.questionCount() !== 0) {
                 self.calculatedScore( Math.round( (self.totalQuestionsCorrect() / self.questionCount() * 100) * 10 ) / 10 );
             }
-
             self.calculatedScoreDate(getNowDateTimeStamp());
-
             self.quizComplete(true);
+            $( ".solutions").addClass( "question-pool" ); // needed for styling of questions
+            var i = 1;
+            $( ".question-pool" ).find('.question').each( function() {
+                var q = $(this).clone();
+                q.appendTo('#solution-'+ i++);
+                q.show();
+                q.find('input').each( function() { $(this).attr('disabled','disabled'); });
+                q.find('.answer[data-correct]').addClass('highlight');
+                q.find('.hint').slideDown();
+                q.find('.description').slideDown();
+            });
         };
+
         self.totalQuestionsCorrect = ko.observable(0);
         self.calculatedScore = ko.observable(0);
         self.calculatedScoreDate = ko.observable('');


### PR DESCRIPTION
This PR addresses issue #2 and allows users to provide a solution overview with the score by adding 

``` html
<div class="solutions">
    <div data-bind="foreach: { data: questions, as: 'question' }">
        <h3>
            Question <span data-bind="text: question.index"></span> (
            <span data-bind="css: {'text-success': question.correct }, visible: question.correct">Correct</span>
            <span data-bind="css: {'text-danger': !question.correct }, visible: !question.correct">Wrong</span>
            )
        </h3>
        <div data-bind="attr: {'id': 'solution-' + question.index}"></div>
    </div>
</div>
```

 to the score section.
